### PR TITLE
Change build task to build the whole solution

### DIFF
--- a/Api/.vscode/tasks.json
+++ b/Api/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/HyAcademy.APIs/HyAcademy.APIs.csproj",
+                "${workspaceFolder}/HyAcademy.sln",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],


### PR DESCRIPTION
Right now VS Code build task build from APIs project, so other top level project such as GraphQL tools does not get build or nuget restore.

This PR changes the task to build from the .sln file.