### PR TITLE
Add concurrency constraint for PR CI workflow

### DIFF
--- a/.github/workflows/main-pr-open-ci-cd.yml
+++ b/.github/workflows/main-pr-open-ci-cd.yml
@@ -23,6 +23,8 @@ jobs:
   deploy_api:
     needs: [create_app]
     uses: nguyenquyhy/Hy-Academy/.github/workflows/module-backend-deploy.yml@main
+    concurrency: 
+      group: pr${{ github.event.pull_request.number }}
     with:
       environment: Pull Requests
       frontendUrl: ${{ needs.create_app.outputs.url }}

--- a/.github/workflows/main-pr-open-ci-cd.yml
+++ b/.github/workflows/main-pr-open-ci-cd.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths: 
       - '.github/workflows/main-pr-open-ci-cd.yml'
+      - '.github/workflows/module-*'
       - 'React/**'
       - 'Api/**'
 

--- a/.github/workflows/main-pr-open-ci-cd.yml
+++ b/.github/workflows/main-pr-open-ci-cd.yml
@@ -23,8 +23,6 @@ jobs:
   deploy_api:
     needs: [create_app]
     uses: nguyenquyhy/Hy-Academy/.github/workflows/module-backend-deploy.yml@main
-    concurrency: 
-      group: pr${{ github.event.pull_request.number }}
     with:
       environment: Pull Requests
       frontendUrl: ${{ needs.create_app.outputs.url }}

--- a/.github/workflows/main-pr-open-ci-cd.yml
+++ b/.github/workflows/main-pr-open-ci-cd.yml
@@ -23,7 +23,7 @@ jobs:
 
   deploy_api:
     needs: [create_app]
-    uses: nguyenquyhy/Hy-Academy/.github/workflows/module-backend-deploy.yml@hy/pr-ci-concurrency
+    uses: nguyenquyhy/Hy-Academy/.github/workflows/module-backend-deploy.yml@main
     with:
       environment: Pull Requests
       frontendUrl: ${{ needs.create_app.outputs.url }}

--- a/.github/workflows/main-pr-open-ci-cd.yml
+++ b/.github/workflows/main-pr-open-ci-cd.yml
@@ -23,7 +23,7 @@ jobs:
 
   deploy_api:
     needs: [create_app]
-    uses: nguyenquyhy/Hy-Academy/.github/workflows/module-backend-deploy.yml@main
+    uses: nguyenquyhy/Hy-Academy/.github/workflows/module-backend-deploy.yml@hy/pr-ci-concurrency
     with:
       environment: Pull Requests
       frontendUrl: ${{ needs.create_app.outputs.url }}

--- a/.github/workflows/module-backend-deploy.yml
+++ b/.github/workflows/module-backend-deploy.yml
@@ -95,6 +95,8 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
+
+    - run: echo ${{ github.ref }}
       
     - name: Azure login
       uses: azure/login@v1.4.2

--- a/.github/workflows/module-backend-deploy.yml
+++ b/.github/workflows/module-backend-deploy.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_docker_image]
     concurrency: 
-      group: pr${{ github.event.pull_request.number }}
+      group: ${{ github.ref }}-api-container-app
     permissions: 
       id-token: write
       contents: read
@@ -96,8 +96,6 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
 
-    - run: echo '${{ github.ref }}'
-      
     - name: Azure login
       uses: azure/login@v1.4.2
       with:

--- a/.github/workflows/module-backend-deploy.yml
+++ b/.github/workflows/module-backend-deploy.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
-
+      
     - name: Azure login
       uses: azure/login@v1.4.2
       with:

--- a/.github/workflows/module-backend-deploy.yml
+++ b/.github/workflows/module-backend-deploy.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
 
-    - run: echo ${{ github.ref }}
+    - run: echo '${{ github.ref }}'
       
     - name: Azure login
       uses: azure/login@v1.4.2

--- a/.github/workflows/module-backend-deploy.yml
+++ b/.github/workflows/module-backend-deploy.yml
@@ -85,6 +85,8 @@ jobs:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     needs: [build_docker_image]
+    concurrency: 
+      group: pr${{ github.event.pull_request.number }}
     permissions: 
       id-token: write
       contents: read


### PR DESCRIPTION
The step to deploy Docker image to ContainerApp might take a long time and can fail if multiple deployments happen at the same time for the same ContainerApp.

This PR adds concurrency group for that deployment job to prevent the issue.