### PR TITLE
Add token cache and block App rendering to prevent loading issue right after logging in

### DIFF
--- a/React/src/ApolloApp.tsx
+++ b/React/src/ApolloApp.tsx
@@ -39,7 +39,7 @@ const ApolloApp = () => {
         <ApolloProvider client={apollo}>
             {inProgress === 'none' || <LoaderBlocking message="Please wait..." />}
             {!!message && <Dialog title="Account" message={message} />}
-            <App />
+            {inProgress === 'none' && <App />}
         </ApolloProvider>
     );
 };

--- a/React/src/auth/authConfig.ts
+++ b/React/src/auth/authConfig.ts
@@ -1,4 +1,4 @@
-import { RedirectRequest } from '@azure/msal-browser';
+import { Configuration, RedirectRequest } from '@azure/msal-browser';
 
 if (!process.env.REACT_APP_B2C_CLIENT_ID) throw new Error('CLIENT_ID must have value');
 if (!process.env.REACT_APP_B2C_API_SCOPE) throw new Error('API_SCOPE must have value');
@@ -7,11 +7,14 @@ if (!process.env.REACT_APP_B2C_SIGNUP_SIGNIN) throw new Error('SIGNUP_SIGNIN mus
 if (!process.env.REACT_APP_B2C_EDIT_PROFILE) throw new Error('EDIT_PROFILE must have value');
 if (!process.env.REACT_APP_B2C_RESET_PASSWORD) throw new Error('RESET_PASSWORD must have value');
 
-export const msalConfig = {
+export const msalConfig: Configuration = {
     auth: {
         clientId: process.env.REACT_APP_B2C_CLIENT_ID,
         authority: process.env.REACT_APP_B2C_SIGNUP_SIGNIN,
         knownAuthorities: [process.env.REACT_APP_B2C_AUTHORITY]
+    },
+    cache: {
+        cacheLocation: 'localStorage'
     }
 };
 

--- a/React/src/auth/lookupTokenAsync.ts
+++ b/React/src/auth/lookupTokenAsync.ts
@@ -2,7 +2,7 @@ import { InteractionRequiredAuthError, IPublicClientApplication } from '@azure/m
 import { loginRequest, loginSilentRequest } from './authConfig';
 
 const lookupTokenAsync = async (instance: IPublicClientApplication, inProgress: string) => {
-    const accounts = await instance.getAllAccounts();
+    const accounts = instance.getAllAccounts();
 
     const account = accounts[0];
     if (inProgress === 'none') {


### PR DESCRIPTION
This is to address 2 issues:
- App is not logged in automatically when opening in a new tab.
- Right after the first login without cache, unauthenticated data/UI shows up because Apollo already loaded the data.